### PR TITLE
Delete email after processing if DELETE_MAILS=true

### DIFF
--- a/src/Command/CheckmailboxCommand.php
+++ b/src/Command/CheckmailboxCommand.php
@@ -267,6 +267,9 @@ class CheckmailboxCommand extends Command
                 $smtptls_reports = array_merge($smtptls_reports,$new_reports['smtptls_reports']);
                 unlink($attachment->filePath);
             }
+            if ($_ENV['DELETE_MAILS'] == 'true') {
+                $mailbox->deleteMail($mailId);
+            }
         }
         return array('num_emails' => $num_emails, 'reports' => array('dmarc_reports' => $dmarc_reports, 'smtptls_reports' => $smtptls_reports));
     }


### PR DESCRIPTION
This commit deletes the emails after processing
if DELETE_MAILS is set to "true".

Do note that I haven't tested the code, but I
have tested the function call
($mailbox->deleteEmail)

This feature is nice for me for example, as I
make reports get sent to an address which then
also saves the email before giving it to this
tool, so I would rather not have multiple
dangling copies, (also including I set quotas on
this mailbox) means that if it doesn't delete the
emails, I'd have to remove them using a external
tool, which would be a bodge, so I prefer if this
could be added to DMARC-SMTPTLS-Reports

The recommended maximum size for a line in the commit message is less than 50 characters, so I am sorry for making the commit message's line 50 characters. (this line is not part of the commit, it's only part of github's description of the PR) 