### PR TITLE
Fix link in pagination buttons

### DIFF
--- a/templates/domains/index.html.twig
+++ b/templates/domains/index.html.twig
@@ -49,12 +49,12 @@
                                   <span class="float-start">&nbsp;</span>
                                   <span class="float-end">
                                   {% if pages.prev %}
-                                    <a href="{{ path('app_logs', {page: pages.page - 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&lt;</a>
+                                    <a href="{{ path('app_domains', {page: pages.page - 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&lt;</a>
                                   {% else %}
                                     <a href="#" class="btn btn-sm btn-light" disabled>&lt;</a>
                                   {% endif %}
                                   {% if pages.next %}
-                                    <a href="{{ path('app_logs', {page: pages.page + 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&gt;</a>
+                                    <a href="{{ path('app_domains', {page: pages.page + 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&gt;</a>
                                   {% else %}
                                     <a href="#" class="btn btn-sm btn-light" disabled>&gt;</a>
                                   {% endif %}


### PR DESCRIPTION
Fixes the pagination buttons on the domain overview, which where linking to the logs overview at `/logs`.

Fixes #35