### PR TITLE
Update GetReportsFromMailboxCommand.php

### DIFF
--- a/src/Command/GetReportsFromMailboxCommand.php
+++ b/src/Command/GetReportsFromMailboxCommand.php
@@ -137,7 +137,9 @@ class GetReportsFromMailboxCommand extends Command
             $report->setMailId($mail->headers->message_id);
             $report->setSuccess(false, 'Failed to open email attachment.');
         } finally {
-            $reports[] = $report;
+            if ($report != null) {
+                $reports[] = $report;
+            }
         }
         
         //Process report


### PR DESCRIPTION
If Mail has no attachment (spam e.g.), the array is assigned with 0 => null, which results in an exception on report processing