### PR TITLE
UI cleanup, adaption for small screens, sidebar fixes

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1,10 +1,12 @@
+
+
 :root, [data-bs-theme=light] {
   --bs-breadcrumb-margin-bottom: 0.2rem;
 }
 
 /* Defaults. */
 /* for extra small screens, show a similar sidebar but full width and only if the menu button is pressed. */
-@media(max-width: 768px) {
+@media(max-width: 1199px) {
     button.navbar-toggler {
         display: inline;
         border-radius: 0;
@@ -31,7 +33,7 @@
         flex-wrap: wrap;
         align-content: start;
         height: 100vH;
-        width: 220px;
+        width: 100vW;
         top: 3rem;
         right: 0;
         padding: 1em;
@@ -45,12 +47,14 @@
     }
 
     .card-body {
-        padding: calc(var(--bs-card-spacer-y) * 0.3);
+        --bs-card-spacer-y: 0.3rem;
+        --bs-card-spacer-x: 0.3rem;
+        padding: var(--bs-card-spacer-x) var(--bs-card-spacer-y);
     }
 
 }
 
-/* [>=sm] For screens between, show a top icon bar with or without labels. */
+/* [>=sm] For screens between, show a top icon bar with or without labels.
 @media(min-width:768px) {
     button.navbar-toggler { display: none; }
     nav#sidebar { display: flex; }
@@ -64,16 +68,19 @@
     div.mainarea { margin-top: 3rem; }
 }
 
-/* [lg] */
+/* [lg] * /
 @media(min-width:992px) {
     nav#sidebar a.nav-link span { display: inline; }
 
 }
+*/
 
 /* For extra wide screens, show a static sidebar at the left, with text, vertically aligned. */
 @media (min-width: 1200px) {
+    button.navbar-toggler { display: none; }
     nav#sidebar {
         position: fixed;
+        display: flex;
         flex-wrap: wrap;
         align-content: start;
         height: 100vH;
@@ -89,15 +96,14 @@
         padding-right: 0;
         padding-top: 0;
     }
+    nav#sidebar a.nav-link-extra { margin-top: 1em };
     div.mainarea {
+        margin-top: 3rem;
         margin-left: 180px;
         width: calc(100vW - 180px);
     }
 }
 
-.breadcrumb-row {
-    background-color: var(--bs-secondary-bg);
-}
 div.breadcrumb-row nav {
     padding-top: 0.3rem;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -84,7 +84,7 @@
         flex-wrap: wrap;
         align-content: start;
         height: 100vH;
-        width: 180px;
+        width: 160px;
         left: 0;
         top: 3rem;
         padding: 1em;
@@ -99,8 +99,8 @@
     nav#sidebar a.nav-link-extra { margin-top: 1em };
     div.mainarea {
         margin-top: 3rem;
-        margin-left: 180px;
-        width: calc(100vW - 180px);
+        margin-left: 160px;
+        width: calc(100vW - 160px);
     }
 }
 
@@ -114,6 +114,7 @@ ol.breadcrumb {
     
 a.navbar-brand {
     font-weight: bold;
+    padding-left:1em;
 }
 
 nav#sidebar .nav-link {
@@ -128,6 +129,10 @@ nav#sidebar a.nav-link.active {
 a.nav-link svg {
     width: 20px;
     height: 20px;
+}
+
+.card-header a.btn-sm {
+    --bs-btn-padding-y: 0;
 }
 
 .help_info {

--- a/public/style.css
+++ b/public/style.css
@@ -1,48 +1,129 @@
-.sidebar {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 100;
-    padding: 90px 0 0;
-    box-shadow: inset -1px 0 0 rgba(0, 0, 0, .1);
-    z-index: 99;
+
+
+:root, [data-bs-theme=light] {
+  --bs-breadcrumb-margin-bottom: 0.2rem;
 }
 
-@media (max-width: 767.98px) {
-    .sidebar {
-        top: 11.5rem;
-        padding: 0;
+/* Defaults. */
+/* for extra small screens, show a similar sidebar but full width and only if the menu button is pressed. */
+@media(max-width: 768px) {
+    button.navbar-toggler {
+        display: inline;
+        border-radius: 0;
+        border: 0;
+        background-color: var(--bs-secondary-bg);
     }
+    nav#sidebar {
+        display: none;
+    }
+    nav#sidebar a.nav-link-extra { margin-top: 1em };
+    nav#sidebar a.nav-link {
+        display: block;
+        width: 100%;
+        font-size: 150%;
+        height: 40px;
+    }
+    nav#sidebar a.nav-link:click {
+        background-color: var(--bs-primary-bg);
+    }
+
+    nav#sidebar.show {
+        position: fixed;
+        display: flex;
+        flex-wrap: wrap;
+        align-content: start;
+        height: 100vH;
+        width: 220px;
+        top: 3rem;
+        right: 0;
+        padding: 1em;
+        background-color: var(--bs-secondary-bg);
+        z-index: 99;
+    }
+
+    div.mainarea {
+        position: relative;
+        top: 3rem;
+    }
+
+    .card-body {
+        padding: calc(var(--bs-card-spacer-y) * 0.3);
+    }
+
+}
+
+/* [>=sm] For screens between, show a top icon bar with or without labels. */
+@media(min-width:768px) {
+    button.navbar-toggler { display: none; }
+    nav#sidebar { display: flex; }
+    nav#sidebar a.nav-link {
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
+        padding-top: 0.2rem;
+    }
+    nav#sidebar a.nav-link-extra { display: none };
+    nav#sidebar a.nav-link span { display: none; }
+    div.mainarea { margin-top: 3rem; }
+}
+
+/* [lg] */
+@media(min-width:992px) {
+    nav#sidebar a.nav-link span { display: inline; }
+
+}
+
+/* For extra wide screens, show a static sidebar at the left, with text, vertically aligned. */
+@media (min-width: 1200px) {
+    nav#sidebar {
+        position: fixed;
+        flex-wrap: wrap;
+        align-content: start;
+        height: 100vH;
+        width: 180px;
+        left: 0;
+        top: 3rem;
+        padding: 1em;
+        background-color: var(--bs-secondary-bg);
+        z-index: 99;
+    }
+    nav#sidebar a.nav-link {
+        padding-left: 0;
+        padding-right: 0;
+        padding-top: 0;
+    }
+    div.mainarea {
+        margin-left: 180px;
+        width: calc(100vW - 180px);
+    }
+}
+
+.breadcrumb-row {
+    background-color: var(--bs-secondary-bg);
+}
+div.breadcrumb-row nav {
+    padding-top: 0.3rem;
+}
+
+ol.breadcrumb {
+    margin-bottom: 0.2rem;
 }
     
-.navbar {
-    box-shadow: inset 0 -1px 0 rgba(0, 0, 0, .1);
+a.navbar-brand {
+    font-weight: bold;
 }
 
-@media (min-width: 767.98px) {
-    .navbar {
-        top: -100;
-        position: sticky;
-        z-index: 999;
-    }
-/*
-    .sidebar {
-        width: 160px;
-    }*/
-}
-
-.sidebar .nav-link {
+nav#sidebar .nav-link {
+    font-size: 120%;
+    height: 36px;
     color: #333;
 }
-
-.sidebar .nav-link svg {
-    width: 20px;
-    height: 20px;
+nav#sidebar a.nav-link.active {
+    color: #0d6efd;
 }
 
-.sidebar .nav-link.active {
-    color: #0d6efd;
+a.nav-link svg {
+    width: 20px;
+    height: 20px;
 }
 
 .help_info {

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -11,8 +11,11 @@
 </head>
 <body>
     <nav class="navbar navbar-light bg-light fixed-top px-2 py-1">
-        <div class="col-12 d-flex align-items-center flex-nowrap justify-content-between">
-            <a class="navbar-brand" href="#">
+        <div class="col-12 d-flex align-items-center flex-nowrap justify-content-left">
+            <button class="navbar-toggler collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#sidebar" aria-controls="sidebar" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <a class="navbar-brand" href="{{ path('app_dashboard') }}">
                 Reports
             </a>
             {% if app.user.email is defined and menuactive is defined %}
@@ -66,9 +69,6 @@
                         {% endif %}
               </nav>
             {% endif %}
-            <button class="navbar-toggler collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#sidebar" aria-controls="sidebar" aria-expanded="false" aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
-            </button>
         </div>
     </nav>
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -10,26 +10,76 @@
     {% block javascripts_header %}{% endblock %}
 </head>
 <body>
-    <nav class="navbar navbar-light bg-light fixed-top p-3">
-        <div class="d-flex col-12 col-md-3 col-lg-2 mb-2 mb-lg-0 flex-wrap flex-md-nowrap justify-content-between">
+    <nav class="navbar navbar-light bg-light fixed-top px-2 py-1">
+        <div class="col-12 col-md-8 d-flex align-items-center flex-nowrap justify-content-between">
             <a class="navbar-brand" href="#">
-                Reports
+                DMARC Reports
             </a>
-            <button class="navbar-toggler d-md-none collapsed mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#sidebar" aria-controls="sidebar" aria-expanded="false" aria-label="Toggle navigation">
+            {% if app.user.email is defined and menuactive is defined %}
+              <nav id="sidebar" class="menubar flex">
+                          <a title="Dashboard" class="text-nowrap nav-link{% if menuactive == "dashboard" %} active{% endif %}" aria-current="page" href="{{ path('app_dashboard') }}">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5m.75-9l3-3 2.148 2.148A12.061 12.061 0 0116.5 7.605" />
+                            </svg>
+                            <span class="ms-1">Dashboard</span>
+                          </a>
+                          <a title="Reports" class="text-nowrap nav-link{% if menuactive == "reports" %} active{% endif %}" href="{{ path('app_reports') }}">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                              <path stroke-linecap="round" stroke-linejoin="round" d="M11.35 3.836c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m8.9-4.414c.376.023.75.05 1.124.08 1.131.094 1.976 1.057 1.976 2.192V16.5A2.25 2.25 0 0118 18.75h-2.25m-7.5-10.5H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V18.75m-7.5-10.5h6.375c.621 0 1.125.504 1.125 1.125v9.375m-8.25-3l1.5 1.5 3-3.75" />
+                            </svg>
+                            <span class="ms-1">Reports</span>
+                          </a>
+                          <a title="Domains" class="text-nowrap nav-link{% if menuactive == "domains" %} active{% endif %}" href="{{ path('app_domains') }}">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                              <path stroke-linecap="round" d="M16.5 12a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0zm0 0c0 1.657 1.007 3 2.25 3S21 13.657 21 12a9 9 0 10-2.636 6.364M16.5 12V8.25" />
+                            </svg>
+                            <span class="ms-1">Domains</span>
+                          </a>
+                        {% if is_granted('ROLE_ADMIN') %}
+                          <a title="Users" class="text-nowrap nav-link{% if menuactive == "users" %} active{% endif %}" href="{{ path('app_users') }}">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                              <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z" />
+                            </svg>
+                            <span class="ms-1">Users</span>
+                          </a>
+                          <a title="Logs" class="text-nowrap nav-link{% if menuactive == "logs" %} active{% endif %}" href="{{ path('app_logs') }}">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                              <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+                            </svg>
+                            <span class="ms-1">Logs</span>
+                          </a>
+
+                          <a title="Check" class="text-nowrap nav-link nav-link-extra link-secondary" href="{{ path('app_checkmailnow') }}">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check-circle" viewBox="0 0 16 16">
+                              <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/>
+                              <path d="m10.97 4.97-.02.022-3.473 4.425-2.093-2.094a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-1.071-1.05"/>
+                            </svg>
+                            <span class="ms-1">Check</span>
+                          </a>
+                          <a title="Logs" class="text-nowrap nav-link nav-link-extra link-danger" href="{{ path('app_logout') }}">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-door-open" viewBox="0 0 16 16">
+                              <path d="M8.5 10c-.276 0-.5-.448-.5-1s.224-1 .5-1 .5.448.5 1-.224 1-.5 1"/>
+                              <path d="M10.828.122A.5.5 0 0 1 11 .5V1h.5A1.5 1.5 0 0 1 13 2.5V15h1.5a.5.5 0 0 1 0 1h-13a.5.5 0 0 1 0-1H3V1.5a.5.5 0 0 1 .43-.495l7-1a.5.5 0 0 1 .398.117M11.5 2H11v13h1V2.5a.5.5 0 0 0-.5-.5M4 1.934V15h6V1.077z"/>
+                            </svg>
+                            <span class="ms-1">Logout</span>
+                          </a>
+
+                          <a class="nav-link"></a>
+                        {% endif %}
+              </nav>
+            {% endif %}
+            <button class="navbar-toggler collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#sidebar" aria-controls="sidebar" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
         </div>
-        <div class="col-12 col-md-4 col-lg-2">
-            
-        </div>
-        <div class="col-12 col-md-5 col-lg-8 d-flex align-items-center justify-content-md-end mt-3 mt-md-0">
-        {% if app.user.getroles is defined and 'ROLE_ADMIN' in app.user.getroles() %}
-        <a href="{{ path('app_checkmailnow') }}" class="btn btn-sm btn-primary mx-4">Check mailbox now</a>
-        {% endif %}
+        <div class="col-12 col-md-3 d-flex align-items-center justify-content-end">
+          {% if app.user.getroles is defined and 'ROLE_ADMIN' in app.user.getroles() %}
+          <a href="{{ path('app_checkmailnow') }}" class="btn btn-sm d-none d-md-inline btn-secondary mx-4">Check</a>
+          {% endif %}
           {% if app.user.email is defined %}
-            <div class="dropdown">
-                <button class="btn dropdown-toggle btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-expanded="false">
-                  {{ 'Hello'|trans }}, {{ app.user.email }}
+            <div class="dropdown d-none d-md-block">
+                <button class="btn btn-sm dropdown-toggle btn-danger dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-expanded="false">
+                  {{ app.user.email }}
                 </button>
                 <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
                   <li><a class="dropdown-item" href="{{ path('app_logout') }}">{{ 'Sign out'|trans }}</a></li>
@@ -39,59 +89,8 @@
         </div>
     </nav>
 
-    <div class="container-fluid">
-        <div class="row">
-            {% if app.user.email is defined and menuactive is defined %}
-            <nav id="sidebar" class="col-md-3 col-lg-1 d-md-block bg-light sidebar collapse">
-                <div class="position-sticky">
-                    <ul class="nav flex-column">
-                        <li class="nav-item">
-                          <a class="nav-link{% if menuactive == "dashboard" %} active{% endif %}" aria-current="page" href="{{ path('app_dashboard') }}">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5m.75-9l3-3 2.148 2.148A12.061 12.061 0 0116.5 7.605" />
-                            </svg>
-                            <span class="ms-2">Dashboard</span>
-                          </a>
-                        </li>
-                        <li class="nav-item">
-                          <a class="nav-link{% if menuactive == "reports" %} active{% endif %}" href="{{ path('app_reports') }}">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                              <path stroke-linecap="round" stroke-linejoin="round" d="M11.35 3.836c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m8.9-4.414c.376.023.75.05 1.124.08 1.131.094 1.976 1.057 1.976 2.192V16.5A2.25 2.25 0 0118 18.75h-2.25m-7.5-10.5H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V18.75m-7.5-10.5h6.375c.621 0 1.125.504 1.125 1.125v9.375m-8.25-3l1.5 1.5 3-3.75" />
-                            </svg>
-                            <span class="ms-2">Reports</span>
-                          </a>
-                        </li>
-                        <li class="nav-item">
-                          <a class="nav-link{% if menuactive == "domains" %} active{% endif %}" href="{{ path('app_domains') }}">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                              <path stroke-linecap="round" d="M16.5 12a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0zm0 0c0 1.657 1.007 3 2.25 3S21 13.657 21 12a9 9 0 10-2.636 6.364M16.5 12V8.25" />
-                            </svg>
-                            <span class="ms-2">Domains</span>
-                          </a>
-                        </li>
-                        {% if is_granted('ROLE_ADMIN') %}
-                        <li class="nav-item">
-                          <a class="nav-link{% if menuactive == "users" %} active{% endif %}" href="{{ path('app_users') }}">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                              <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z" />
-                            </svg>
-                            <span class="ms-2">Users</span>
-                          </a>
-                        </li>
-                        <li class="nav-item">
-                          <a class="nav-link{% if menuactive == "logs" %} active{% endif %}" href="{{ path('app_logs') }}">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                              <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
-                            </svg>
-                            <span class="ms-2">Logs</span>
-                          </a>
-                        </li>
-                        {% endif %}
-                      </ul>
-                </div>
-            </nav>
-            {% endif %}
-            <main class="col-md-9 ms-sm-auto col-lg-11 px-md-4 py-4">
+    <div class="mainarea container-fluid">
+        <div class="breadcrumb-row row border-bottom">
               <div class="clearfix">
                 <span class="float-start">
                   {% if app.user.email is defined %}
@@ -110,6 +109,9 @@
                   {% block addButton %}{% endblock %}
                 </span>
               </div>
+        </div>
+        <div class="row">
+            <main class="col-md-12 ms-sm-auto col-lg-12 px-1 py-2">
 {% block body %}{% endblock %}
             </main>
         </div>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -11,9 +11,9 @@
 </head>
 <body>
     <nav class="navbar navbar-light bg-light fixed-top px-2 py-1">
-        <div class="col-12 col-md-8 d-flex align-items-center flex-nowrap justify-content-between">
+        <div class="col-12 d-flex align-items-center flex-nowrap justify-content-between">
             <a class="navbar-brand" href="#">
-                DMARC Reports
+                Reports
             </a>
             {% if app.user.email is defined and menuactive is defined %}
               <nav id="sidebar" class="menubar flex">
@@ -50,16 +50,14 @@
                           </a>
 
                           <a title="Check" class="text-nowrap nav-link nav-link-extra link-secondary" href="{{ path('app_checkmailnow') }}">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check-circle" viewBox="0 0 16 16">
-                              <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/>
-                              <path d="m10.97 4.97-.02.022-3.473 4.425-2.093-2.094a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-1.071-1.05"/>
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                             </svg>
-                            <span class="ms-1">Check</span>
+                            <span class="ms-1">Check Mail</span>
                           </a>
                           <a title="Logs" class="text-nowrap nav-link nav-link-extra link-danger" href="{{ path('app_logout') }}">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-door-open" viewBox="0 0 16 16">
-                              <path d="M8.5 10c-.276 0-.5-.448-.5-1s.224-1 .5-1 .5.448.5 1-.224 1-.5 1"/>
-                              <path d="M10.828.122A.5.5 0 0 1 11 .5V1h.5A1.5 1.5 0 0 1 13 2.5V15h1.5a.5.5 0 0 1 0 1h-13a.5.5 0 0 1 0-1H3V1.5a.5.5 0 0 1 .43-.495l7-1a.5.5 0 0 1 .398.117M11.5 2H11v13h1V2.5a.5.5 0 0 0-.5-.5M4 1.934V15h6V1.077z"/>
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                              <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 9V5.25A2.25 2.25 0 0 1 10.5 3h6a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 16.5 21h-6a2.25 2.25 0 0 1-2.25-2.25V15M12 9l3 3m0 0-3 3m3-3H2.25" />
                             </svg>
                             <span class="ms-1">Logout</span>
                           </a>
@@ -71,21 +69,6 @@
             <button class="navbar-toggler collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#sidebar" aria-controls="sidebar" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
-        </div>
-        <div class="col-12 col-md-3 d-flex align-items-center justify-content-end">
-          {% if app.user.getroles is defined and 'ROLE_ADMIN' in app.user.getroles() %}
-          <a href="{{ path('app_checkmailnow') }}" class="btn btn-sm d-none d-md-inline btn-secondary mx-4">Check</a>
-          {% endif %}
-          {% if app.user.email is defined %}
-            <div class="dropdown d-none d-md-block">
-                <button class="btn btn-sm dropdown-toggle btn-danger dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-expanded="false">
-                  {{ app.user.email }}
-                </button>
-                <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-                  <li><a class="dropdown-item" href="{{ path('app_logout') }}">{{ 'Sign out'|trans }}</a></li>
-                </ul>
-              </div>
-          {% endif %}
         </div>
     </nav>
 

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -6,18 +6,18 @@
 
 {% block body %}
                 <div class="row">
-                    <div class="col-12 col-xl-6 mb-4 mb-lg-4">
+                    <div class="col-12 col-xxl-6 mb-4 mb-lg-4">
                         <div class="card">
                             <h5 class="card-header">Latest DMARC reports</h5>
                             <div class="card-body">
                                 <div class="table-responsive">
-                                    <table class="table">
+                                    <table class="table table-sm table-compact">
                                         <thead>
                                           <tr>
                                             <th scope="col">Id</th>
                                             <th scope="col">Domain</th>
-                                            <th scope="col">Reporter</th>
-                                            <th scope="col">Messages</th>
+                                            <th class="d-none d-md-table-cell" scope="col">Reporter</th>
+                                            <th scope="col">Msg</th>
                                             <th scope="col">Results</th>
                                             <th scope="col"></th>
                                           </tr>
@@ -27,7 +27,7 @@
                                           <tr {% for user in report.seen %}{% else %}class="table-warning"{% endfor %}>
                                             <th scope="row">{{ report.id }}</th>
                                             <td>{{ report.domain.fqdn }}</td>
-                                            <td>{{ report.organisation }}</td>
+                                            <td class="d-none d-md-table-cell">{{ report.organisation }}</td>
                                             <td>{{ report.dmarc_records.count }}</td>
                                             <td>
                                               {% set dkim_pass = true %}
@@ -40,10 +40,17 @@
                                                     {% set spf_pass = false %}
                                                   {% endif %}
                                               {% endfor %}
-                                              <span class="btn btn-sm btn-{% if spf_pass %}success{% else %}danger{% endif %}">spf</span>
-                                              <span class="btn btn-sm btn-{% if dkim_pass %}success{% else %}danger{% endif %}">dkim</span>
+                                              <span class="badge badge-pill text-bg-{% if spf_pass %}success{% else %}danger{% endif %}">SPF</span>
+                                              <span class="badge badge-pill text-bg-{% if dkim_pass %}success{% else %}danger{% endif %}">DKIM</span>
                                             </td>
-                                            <td><a href="{{ path('app_dmarc_reports_report', {report: report.id}) }}" class="btn btn-sm btn-primary">Open Report</a></td>
+                                            <td>
+                                              <a href="{{ path('app_dmarc_reports_report', {report: report.id}) }}" class="link-primary">
+                                                <!-- Bootstrap icon 'eye-fill' -->
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye-fill" viewBox="0 0 16 16">
+                                                  <path d="M10.5 8a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0"/>
+                                                  <path d="M0 8s3-5.5 8-5.5S16 8 16 8s-3 5.5-8 5.5S0 8 0 8m8 3.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7"/>
+                                                </svg></a>
+                                            </td>
                                           </tr>
                                         {% endfor %}
                                         </tbody>
@@ -53,12 +60,12 @@
                             </div>
                         </div>
                     </div>
-                    <div class="col-12 col-xl-6 mb-4 mb-lg-4">
+                    <div class="col-12 col-xxl-6 mb-4 mb-lg-4">
                         <div class="card">
                             <h5 class="card-header">Latest SMTP-TLS reports</h5>
                             <div class="card-body">
                                 <div class="table-responsive">
-                                    <table class="table">
+                                    <table class="table table-sm table-compact">
                                         <thead>
                                           <tr>
                                             <th scope="col">Id</th>
@@ -120,7 +127,7 @@
                             <h5 class="card-header">Latest logs</h5>
                             <div class="card-body">
                                 <div class="table-responsive">
-                                    <table class="table">
+                                    <table class="table table-sm table-compact">
                                         <thead>
                                           <tr>
                                             <th scope="col">Id</th>

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -14,10 +14,10 @@
                                     <table class="table table-sm table-compact">
                                         <thead>
                                           <tr>
-                                            <th scope="col" class="d-none d-lg-table-cell">Id</th>
+                                            <th class="d-none d-md-table-cell" scope="col">Id</th>
                                             <th scope="col">Domain</th>
                                             <th class="d-none d-md-table-cell" scope="col">Reporter</th>
-                                            <th scope="col">Msg</th>
+                                            <th scope="col">Messages</th>
                                             <th scope="col">Results</th>
                                             <th scope="col"></th>
                                           </tr>
@@ -25,7 +25,7 @@
                                         <tbody>
                                         {% for report in dmarcreports %}
                                           <tr {% for user in report.seen %}{% else %}class="table-warning"{% endfor %}>
-                                            <th scope="row" class="d-none d-lg-table-cell">{{ report.id }}</th>
+                                            <th class="d-none d-md-table-cell" scope="row">{{ report.id }}</th>
                                             <td>{{ report.domain.fqdn }}</td>
                                             <td class="d-none d-md-table-cell">{{ report.organisation }}</td>
                                             <td>{{ report.dmarc_records.count }}</td>
@@ -45,10 +45,9 @@
                                             </td>
                                             <td>
                                               <a href="{{ path('app_dmarc_reports_report', {report: report.id}) }}" class="link-primary">
-                                                <!-- Bootstrap icon 'eye-fill' -->
-                                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye-fill" viewBox="0 0 16 16">
-                                                  <path d="M10.5 8a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0"/>
-                                                  <path d="M0 8s3-5.5 8-5.5S16 8 16 8s-3 5.5-8 5.5S0 8 0 8m8 3.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7"/>
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-6 h-6">
+                                                  <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
+                                                  <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
                                                 </svg></a>
                                             </td>
                                           </tr>
@@ -68,7 +67,7 @@
                                     <table class="table table-sm table-compact">
                                         <thead>
                                           <tr>
-                                            <th scope="col" class="d-none d-lg-table-cell">Id</th>
+                                            <th scope="col">Id</th>
                                             <th scope="col">Domain</th>
                                             <th scope="col">Reporter</th>
                                             <th scope="col">Results</th>
@@ -78,14 +77,14 @@
                                         <tbody>
                                         {% for report in smtptlsreports %}
                                           <tr {% for user in report.seen %}{% else %}class="table-warning"{% endfor %}>
-                                            <th scope="row" class="d-none d-lg-table-cell">{{ report.id }}</th>
+                                            <th scope="row">{{ report.id }}</th>
                                             <td>
                                               {% for policy in report.smtptls_policies %}
                                                 {{policy.policydomain.fqdn}}<br>
                                               {% endfor %}
                                             </td>
                                             <td>{{ report.organisation }}</td>
-                                            <td class="d-none d-lg-table-cell">
+                                            <td>
                                               {% set sts_type = false %}
                                               {% set sts_version = true %}
                                               {% set sts_mode = true %}
@@ -109,38 +108,11 @@
                                               <br>
                                               {% endfor %}
                                             </td>
-                                            <td class="text-end">
-                                              <a href="{{ path('app_smtptls_reports_report', {report: report.id}) }}" class="btn btn-sm btn-primary" class="btn btn-sm btn-primary" data-toggle="tooltip" data-placement="top" title="Open Report">
-                                                <svg height='20px' width='20px' xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                                                  <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 9v.906a2.25 2.25 0 0 1-1.183 1.981l-6.478 3.488M2.25 9v.906a2.25 2.25 0 0 0 1.183 1.981l6.478 3.488m8.839 2.51-4.66-2.51m0 0-1.023-.55a2.25 2.25 0 0 0-2.134 0l-1.022.55m0 0-4.661 2.51m16.5 1.615a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V8.844a2.25 2.25 0 0 1 1.183-1.981l7.5-4.039a2.25 2.25 0 0 1 2.134 0l7.5 4.039a2.25 2.25 0 0 1 1.183 1.98V19.5Z" />
-                                                </svg>
-                                              </a>
-                                            </td>
-                                          </tr>
-                                          <tr class="d-table-row d-lg-none {% for user in report.seen %}{% else %} table-warning{% endfor %}">
-                                            <td colspan="3">
-                                              {% set sts_type = false %}
-                                              {% set sts_version = true %}
-                                              {% set sts_mode = true %}
-                                              {% for policy in report.smtptls_policies %}
-                                                  <span class="btn btn-sm btn-{% if policy.summarysuccessfulcount == 0 %}secondary{% else %}success{% endif %}">{{ policy.summarysuccessfulcount }} Successful</span>
-                                                  <span class="btn btn-sm btn-{% if policy.summarysuccessfulcount == 0 %}danger{% else %}success{% endif %}">{{ policy.summaryfailedcount }} Failed</span>
-                                                  {% if policy.policytype == 'no-policy-found' %}
-                                                    <span class="btn btn-sm btn-danger">no-policy-found</span>
-                                                  {% else %}
-                                                    {% if policy.policytype == 'sts' %}
-                                                      {% if policy.policystringversion == 'STSv1' %}
-                                                        <span class="btn btn-sm btn-success">STSv1</span>
-                                                      {% else %}
-                                                        <span class="btn btn-sm btn-danger">Policy version empty</span>
-                                                      {% endif %}
-                                                      <span class="btn btn-sm btn-{% if policy.policystringmode == 'enforce' %}success{% elseif policy.policystringmode == 'testing' %}warning{% else %}danger{% endif %}">{% if policy.policystringmode %}{{ policy.policystringmode }}{% else %}Policy mode empty{% endif %}</span>
-                                                    {% elseif policy.policytype == 'tlsa' %}
-                                                      <span class="btn btn-sm btn-success">TLSA</span>
-                                                    {% endif %}
-                                                  {% endif %}
-                                              <br>
-                                              {% endfor %}
+                                            <td><a href="{{ path('app_smtptls_reports_report', {report: report.id}) }}" class="btn btn-sm btn-primary">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-6 h-6">
+                                                  <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
+                                                  <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+                                                </svg></a>
                                             </td>
                                           </tr>
                                         {% endfor %}
@@ -162,7 +134,7 @@
                                     <table class="table table-sm table-compact">
                                         <thead>
                                           <tr>
-                                            <th scope="col" class="d-none d-lg-table-cell">Id</th>
+                                            <th scope="col">Id</th>
                                             <th scope="col">Date &amp; Time</th>
                                             <th scope="col">Message</th>
                                           </tr>
@@ -170,7 +142,7 @@
                                         <tbody>
                                         {% for log in logs %}
                                           <tr {% if log.success == false %}class="table-danger"{% endif %}>
-                                            <th scope="row" class="d-none d-lg-table-cell">{{ log.id }}</th>
+                                            <th scope="row">{{ log.id }}</th>
                                             <td>{{ log.time|date("d-M-Y H:i:s") }}</td>
                                             <td>{{ log.message }}</td>
                                           </tr>

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -16,8 +16,7 @@
                                           <tr>
                                             <th class="d-none d-md-table-cell" scope="col">Id</th>
                                             <th scope="col">Domain</th>
-                                            <th class="d-none d-md-table-cell" scope="col">Reporter</th>
-                                            <th scope="col">Messages</th>
+                                            <th scope="col">Reporter</th>
                                             <th scope="col">Results</th>
                                             <th scope="col"></th>
                                           </tr>
@@ -28,7 +27,6 @@
                                             <th class="d-none d-md-table-cell" scope="row">{{ report.id }}</th>
                                             <td>{{ report.domain.fqdn }}</td>
                                             <td class="d-none d-md-table-cell">{{ report.organisation }}</td>
-                                            <td>{{ report.dmarc_records.count }}</td>
                                             <td>
                                               {% set dkim_pass = true %}
                                               {% set spf_pass = true %}

--- a/templates/dmarc_reports/index.html.twig
+++ b/templates/dmarc_reports/index.html.twig
@@ -8,74 +8,87 @@
                         <div class="card">
                             <h5 class="card-header">DMARC Reports</h5>
                             <div class="card-body">
-                                <div class="table-responsive">
-                                    <table class="table">
-                                        <thead>
-                                          <tr>
-                                            <th scope="col">Id</th>
-                                            <th scope="col">Domain</th>
-                                            <th scope="col">Date/Time Range</th>
-                                            <th scope="col">Reporter</th>
-                                            <th scope="col">External Report Id</th>
-                                            <th scope="col">Messages</th>
-                                            <th scope="col">Results</th>
-                                            <th scope="col"></th>
-                                          </tr>
-                                        </thead>
-                                        <tbody>
-                                        {% for report in reports %}
-                                          <tr {% for user in report.seen %}{% else %}class="table-warning"{% endfor %}>
-                                            <th scope="row">{{ report.id }}</th>
-                                            <td>{{ report.domain.fqdn }}</td>
-                                            <td>
-                                              <div class="clearfix">
-                                                <span class="float-start">{{ report.begintime|date("d-M-Y H:i:s") }}</span>
-                                                <span class="float-end">{{ report.endtime|date("d-M-Y H:i:s") }}</span>
-                                              </div>
-                                            </td>
-                                            <td>{{ report.organisation }}</td>
-                                            <td>{{ report.externalid }}</td>
-                                            <td>{{ report.dmarc_records.count }}</td>
-                                            <td>
-                                              {% set dkim_pass = true %}
-                                              {% set spf_pass = true %}
-                                              {% for record in report.dmarc_records %}
-                                                  {% if record.policydkim != "pass" %}
-                                                    {% set dkim_pass = false %}
-                                                  {% endif %}
-                                                  {% if record.policyspf != "pass" %}
-                                                    {% set spf_pass = false %}
-                                                  {% endif %}
-                                              {% endfor %}
-                                              <span class="btn btn-sm btn-{% if spf_pass %}success{% else %}danger{% endif %}">spf</span>
-                                              <span class="btn btn-sm btn-{% if dkim_pass %}success{% else %}danger{% endif %}">dkim</span>
-                                            </td>
-                                            <td>
-                                              <a href="{{ path('app_dmarc_reports_report', {report: report.id}) }}" class="btn btn-sm btn-primary">Open Report</a>
-                                              <a href="{{ path('app_dmarc_reports_delete', {report: report.id}) }}" class="btn btn-sm btn-danger"  onclick="return confirm('{{'Are you sure? this can not be undone'|trans}}');">Delete</a>
-                                            </td>
-                                          </tr>
-                                        {% endfor %}
-                                        </tbody>
-                                      </table>
-                                </div>
-                                <div class="clearfix">
-                                  <span class="float-start">&nbsp;</span>
-                                  <span class="float-end">
-                                  {% if pages.prev %}
-                                    <a href="{{ path('app_dmarc_reports', {page: pages.page - 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&lt;</a>
-                                  {% else %}
-                                    <a href="#" class="btn btn-sm btn-light" disabled>&lt;</a>
-                                  {% endif %}
-                                  {% if pages.next %}
-                                    <a href="{{ path('app_dmarc_reports', {page: pages.page + 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&gt;</a>
-                                  {% else %}
-                                    <a href="#" class="btn btn-sm btn-light" disabled>&gt;</a>
-                                  {% endif %}
-                                  </span>
-                                </div>
-                                
-                            </div>
-                        </div>
+                      <div class="table-responsive">
+                          <table class="table table-sm table-compact">
+                              <thead>
+                                <tr>
+                                  <th scope="col">Id</th>
+                                  <th scope="col">Date</th>
+                                  <th class="d-none d-lg-table-cell" scope="col">Msg</th>
+                                  <th scope="col">Domain</th>
+                                  <th class="d-none d-md-table-cell"  scope="col">Reporter</th>
+                                  <th class="d-none d-lg-table-cell" scope="col">External Id</th>
+                                  <th scope="col">Results</th>
+                                  <th scope="col"></th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                              {% for report in reports %}
+                                <tr {% for user in report.seen %}{% else %}class="table-warning"{% endfor %}>
+                                  <th scope="row">{{ report.id }}</th>
+                                  <td>
+                                    <div class="clearfix">
+                                      {{ report.begintime|date("Y-m-d H:i:s")|replace({ '00:00:00': '', '23:59:59': '' }) }}
+                                      {% if report.begintime|date("Y-m-d") != report.endtime|date("Y-m-d") %}
+                                        <span class="d-none d-lg-inline">
+                                          .. 
+                                          {{ report.endtime|date("Y-m-d H:i:s")|replace({ '00:00:00': '', '23:59:59': '' }) }}
+                                        </span>
+                                      {% endif %}
+                                    </div>
+                                  </td>
+                                  <td class="d-none d-lg-table-cell">{{ report.dmarc_records.count }}</td>
+                                  <td>{{ report.domain.fqdn }}</td>
+                                  <td class="d-none d-md-table-cell">{{ report.organisation }}</td>
+                                  <td class="d-none d-lg-table-cell" title="{{ report.externalid }}">{{ report.externalid|slice(0,8) }}...</td>
+                                  <td class="text-nowrap">
+                                    {% set dkim_pass = true %}
+                                    {% set spf_pass = true %}
+                                    {% for record in report.dmarc_records %}
+                                        {% if record.policydkim != "pass" %}
+                                          {% set dkim_pass = false %}
+                                        {% endif %}
+                                        {% if record.policyspf != "pass" %}
+                                          {% set spf_pass = false %}
+                                        {% endif %}
+                                    {% endfor %}
+                                    <span class="badge badge-pill text-bg-{% if spf_pass %}success{% else %}danger{% endif %}">SPF</span>
+                                    <span class="badge badge-pill text-bg-{% if dkim_pass %}success{% else %}danger{% endif %}">DKIM</span>
+                                  </td>
+                                  <td class="text-nowrap">
+                                    <a href="{{ path('app_dmarc_reports_report', {report: report.id}) }}" class="link-primary px-2" title="View details">
+                                      <!-- Bootstrap icon 'eye-fill' -->
+                                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye-fill" viewBox="0 0 16 16">
+                                        <path d="M10.5 8a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0"/>
+                                        <path d="M0 8s3-5.5 8-5.5S16 8 16 8s-3 5.5-8 5.5S0 8 0 8m8 3.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7"/>
+                                      </svg></a>
+                                    <a href="{{ path('app_dmarc_reports_delete', {report: report.id}) }}" class="link-danger" title="Delete entry ..." onclick="return confirm('{{'Are you sure? this can not be undone'|trans}}');">
+                                      <!-- Bootstrap icon 'trash-fill' -->
+                                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash-fill" viewBox="0 0 16 16">
+                                        <path d="M2.5 1a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1H3v9a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V4h.5a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H10a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1zm3 4a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 .5-.5M8 5a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7A.5.5 0 0 1 8 5m3 .5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 1 0"/>
+                                      </svg></a>
+                                  </td>
+                                </tr>
+                              {% endfor %}
+                              </tbody>
+                            </table>
+                      </div>
+                      <div>
+                        <span class="d-flex justify-content-center">
+                        {% if pages.prev %}
+                          <a href="{{ path('app_dmarc_reports', {page: pages.page - 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&lt;</a>
+                        {% else %}
+                          <a href="#" class="btn btn-sm btn-light" disabled>&lt;</a>
+                        {% endif %}
+                        &nbsp;
+                        {% if pages.next %}
+                          <a href="{{ path('app_dmarc_reports', {page: pages.page + 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&gt;</a>
+                        {% else %}
+                          <a href="#" class="btn btn-sm btn-light" disabled>&gt;</a>
+                        {% endif %}
+                        </span>
                     </div>
+                  </div>
+                </div>
+              </div>
 {% endblock %}

--- a/templates/dmarc_reports/index.html.twig
+++ b/templates/dmarc_reports/index.html.twig
@@ -6,7 +6,22 @@
                 <div class="row">
                     <div class="col-12 col-xl-12 mb-4 mb-lg-0">
                         <div class="card">
-                            <h5 class="card-header">DMARC Reports</h5>
+                            <h5 class="card-header d-flex justify-content-between">
+                              <span class="d-flex">DMARC Reports</span>
+                              <span class="d-flex">
+                        {% if pages.prev %}
+                          <a href="{{ path('app_dmarc_reports', {page: pages.page - 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&lt;</a>
+                        {% else %}
+                          <a href="#" class="btn btn-sm btn-light" disabled>&lt;</a>
+                        {% endif %}
+                        &nbsp;
+                        {% if pages.next %}
+                          <a href="{{ path('app_dmarc_reports', {page: pages.page + 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&gt;</a>
+                        {% else %}
+                          <a href="#" class="btn btn-sm btn-light" disabled>&gt;</a>
+                        {% endif %}
+                              </span>
+                            </h5>
                             <div class="card-body">
                       <div class="table-responsive">
                           <table class="table table-sm table-compact">
@@ -14,9 +29,8 @@
                                 <tr>
                                   <th class="d-none d-md-table-cell" scope="col">Id</th>
                                   <th scope="col">Date</th>
-                                  <th class="d-none d-md-table-cell"  scope="col">Messages</th>
                                   <th scope="col">Domain</th>
-                                  <th class="d-none d-md-table-cell"  scope="col">Reporter</th>
+                                  <th scope="col">Reporter</th>
                                   <th class="d-none d-lg-table-cell" scope="col">External Id</th>
                                   <th scope="col">Results</th>
                                   <th scope="col"></th>
@@ -37,7 +51,6 @@
                                       {% endif %}
                                     </div>
                                   </td>
-                                  <td class="d-none d-md-table-cell" >{{ report.dmarc_records.count }}</td>
                                   <td>{{ report.domain.fqdn }}</td>
                                   <td class="d-none d-md-table-cell">{{ report.organisation }}</td>
                                   <td class="d-none d-lg-table-cell" title="{{ report.externalid }}">{{ report.externalid|slice(0,8) }}...</td>
@@ -71,22 +84,7 @@
                               </tbody>
                             </table>
                       </div>
-                      <div>
-                        <span class="d-flex justify-content-center">
-                        {% if pages.prev %}
-                          <a href="{{ path('app_dmarc_reports', {page: pages.page - 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&lt;</a>
-                        {% else %}
-                          <a href="#" class="btn btn-sm btn-light" disabled>&lt;</a>
-                        {% endif %}
-                        &nbsp;
-                        {% if pages.next %}
-                          <a href="{{ path('app_dmarc_reports', {page: pages.page + 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&gt;</a>
-                        {% else %}
-                          <a href="#" class="btn btn-sm btn-light" disabled>&gt;</a>
-                        {% endif %}
-                        </span>
                     </div>
                   </div>
                 </div>
-              </div>
 {% endblock %}

--- a/templates/dmarc_reports/index.html.twig
+++ b/templates/dmarc_reports/index.html.twig
@@ -6,15 +6,15 @@
                 <div class="row">
                     <div class="col-12 col-xl-12 mb-4 mb-lg-0">
                         <div class="card">
-                        <h5 class="card-header">DMARC Reports</h5>
-                        <div class="card-body">
-                          <div class="table-responsive">
-                            <table class="table table-sm table-compact">
+                            <h5 class="card-header">DMARC Reports</h5>
+                            <div class="card-body">
+                      <div class="table-responsive">
+                          <table class="table table-sm table-compact">
                               <thead>
                                 <tr>
-                                  <th scope="col">Id</th>
+                                  <th class="d-none d-md-table-cell" scope="col">Id</th>
                                   <th scope="col">Date</th>
-                                  <th class="d-none d-lg-table-cell" scope="col">Msg</th>
+                                  <th class="d-none d-md-table-cell"  scope="col">Messages</th>
                                   <th scope="col">Domain</th>
                                   <th class="d-none d-md-table-cell"  scope="col">Reporter</th>
                                   <th class="d-none d-lg-table-cell" scope="col">External Id</th>
@@ -25,7 +25,7 @@
                               <tbody>
                               {% for report in reports %}
                                 <tr {% for user in report.seen %}{% else %}class="table-warning"{% endfor %}>
-                                  <th scope="row">{{ report.id }}</th>
+                                  <th class="d-none d-md-table-cell" scope="row">{{ report.id }}</th>
                                   <td>
                                     <div class="clearfix">
                                       {{ report.begintime|date("Y-m-d H:i:s")|replace({ '00:00:00': '', '23:59:59': '' }) }}
@@ -37,7 +37,7 @@
                                       {% endif %}
                                     </div>
                                   </td>
-                                  <td class="d-none d-lg-table-cell">{{ report.dmarc_records.count }}</td>
+                                  <td class="d-none d-md-table-cell" >{{ report.dmarc_records.count }}</td>
                                   <td>{{ report.domain.fqdn }}</td>
                                   <td class="d-none d-md-table-cell">{{ report.organisation }}</td>
                                   <td class="d-none d-lg-table-cell" title="{{ report.externalid }}">{{ report.externalid|slice(0,8) }}...</td>
@@ -57,15 +57,13 @@
                                   </td>
                                   <td class="text-nowrap">
                                     <a href="{{ path('app_dmarc_reports_report', {report: report.id}) }}" class="link-primary px-2" title="View details">
-                                      <!-- Bootstrap icon 'eye-fill' -->
-                                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye-fill" viewBox="0 0 16 16">
-                                        <path d="M10.5 8a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0"/>
-                                        <path d="M0 8s3-5.5 8-5.5S16 8 16 8s-3 5.5-8 5.5S0 8 0 8m8 3.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7"/>
+                                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-6 h-6">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
                                       </svg></a>
                                     <a href="{{ path('app_dmarc_reports_delete', {report: report.id}) }}" class="link-danger" title="Delete entry ..." onclick="return confirm('{{'Are you sure? this can not be undone'|trans}}');">
-                                      <!-- Bootstrap icon 'trash-fill' -->
-                                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash-fill" viewBox="0 0 16 16">
-                                        <path d="M2.5 1a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1H3v9a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V4h.5a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H10a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1zm3 4a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 .5-.5M8 5a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7A.5.5 0 0 1 8 5m3 .5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 1 0"/>
+                                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-6 h-6">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
                                       </svg></a>
                                   </td>
                                 </tr>

--- a/templates/domains/index.html.twig
+++ b/templates/domains/index.html.twig
@@ -11,15 +11,24 @@
                             <h5 class="card-header">Domains</h5>
                             <div class="card-body">
                                 <div class="table-responsive">
-                                    <table class="table">
+                                    <table class="table table-sm table-compact">
                                         <thead>
                                           <tr>
                                             <th scope="col">Id</th>
                                             <th scope="col">Domain FQDN</th>
                                             <th scope="col">Mailhost</th>
-                                            <th scope="col">MX Records</th>
-                                            <th scope="col">Total DMARC reports</th>
-                                            <th scope="col">Total SMTP-TLS policies</th>
+                                            <th scope="col">
+                                              MX <span class="d-none d-md-inline">Records</span>
+                                            </th>
+                                            <th scope="col">
+                                              <span class="d-none d-md-inline">Total DMARC reports</span>
+                                              <span class="d-md-none">#DMARC</span>
+                                            </th>
+                                            <th scope="col">
+                                              <span class="d-none d-md-inline">Total SMTP-TLS policies</span>
+                                              <span class="d-md-none">#SMTPTLS</span>
+                                            
+                                            </th>
                                             <th scope="col">Action</th>
                                           </tr>
                                         </thead>
@@ -36,23 +45,32 @@
                                             </td>
                                             <td>{{ domain.dmarc_reports|length }}</td>
                                             <td>{{ domain.smtptls_policies|length }}</td>
-                                            <td>
-                                                <a href="{{ path('app_domains_edit', {id: domain.id}) }}" class="btn btn-sm btn-secondary">Edit</a>
-                                                <a href="{{ path('app_domains_delete', {id: domain.id}) }}" class="btn btn-sm btn-danger"  onclick="return confirm('{{'Are you sure? this will also delete all its reports and can not be undone'|trans}}');">Delete</a>
+                                            <td class="text-nowrap">
+                                                <a href="{{ path('app_domains_edit', {id: domain.id}) }}" class="link-primary px-2">
+                                                  <!-- Bootstrap icon 'eye-fill' -->
+                                                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye-fill" viewBox="0 0 16 16">
+                                                    <path d="M10.5 8a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0"/>
+                                                    <path d="M0 8s3-5.5 8-5.5S16 8 16 8s-3 5.5-8 5.5S0 8 0 8m8 3.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7"/>
+                                                  </svg></a>
+                                                <a href="{{ path('app_domains_delete', {id: domain.id}) }}" class="link-danger"  onclick="return confirm('{{'Are you sure? this will also delete all its reports and can not be undone'|trans}}');">
+                                                  <!-- Bootstrap icon 'trash-fill' -->
+                                                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash-fill" viewBox="0 0 16 16">
+                                                    <path d="M2.5 1a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1H3v9a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V4h.5a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H10a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1zm3 4a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 .5-.5M8 5a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7A.5.5 0 0 1 8 5m3 .5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 1 0"/>
+                                                  </svg></a>
                                             </td>
                                           </tr>
                                         {% endfor %}
                                         </tbody>
                                       </table>
                                 </div>
-                                <div class="clearfix">
-                                  <span class="float-start">&nbsp;</span>
-                                  <span class="float-end">
+                                <div>
+                                  <span class="d-flex justify-content-center">
                                   {% if pages.prev %}
                                     <a href="{{ path('app_domains', {page: pages.page - 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&lt;</a>
                                   {% else %}
                                     <a href="#" class="btn btn-sm btn-light" disabled>&lt;</a>
                                   {% endif %}
+                                  &nbsp;
                                   {% if pages.next %}
                                     <a href="{{ path('app_domains', {page: pages.page + 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&gt;</a>
                                   {% else %}

--- a/templates/domains/index.html.twig
+++ b/templates/domains/index.html.twig
@@ -14,19 +14,19 @@
                                     <table class="table table-sm table-compact">
                                         <thead>
                                           <tr>
-                                            <th scope="col" class="d-none d-lg-table-cell">Id</th>
+                                            <th class="d-none d-md-table-cell" scope="col">Id</th>
                                             <th scope="col">Domain FQDN</th>
-                                            <th scope="col">Mailhost</th>
+                                            <th class="d-none d-md-table-cell" scope="col">Mailhost</th>
                                             <th scope="col">
                                               MX <span class="d-none d-md-inline">Records</span>
                                             </th>
-                                            <th scope="col">
+                                            <th class="text-end" scope="col">
                                               <span class="d-none d-md-inline">Total DMARC reports</span>
-                                              <span class="d-md-none">#DMARC</span>
+                                              <span class="d-md-none text-nowrap"># DMARC</span>
                                             </th>
-                                            <th scope="col">
+                                            <th class="text-end" scope="col">
                                               <span class="d-none d-md-inline">Total SMTP-TLS policies</span>
-                                              <span class="d-md-none">#SMTPTLS</span>
+                                              <span class="d-md-none text-nowrap"># TLS</span>
                                             
                                             </th>
                                             <th scope="col">Action</th>
@@ -35,16 +35,16 @@
                                         <tbody>
                                         {% for domain in domains %}
                                           <tr>
-                                            <th scope="row" class="d-none d-lg-table-cell">{{ domain.id }}</th>
+                                            <th class="d-none d-md-table-cell" scope="row">{{ domain.id }}</th>
                                             <td>{{ domain.fqdn }}</td>
-                                            <td class="d-none d-lg-table-cell">{{ domain.mailhost }}</td>
-                                            <td class="d-none d-lg-table-cell">
+                                            <td class="d-none d-md-table-cell">{{ domain.mailhost }}</td>
+                                            <td>
                                               {% for mx in domain.mxrecords %}
                                                 {{ mx.name }}<br>
                                               {% endfor %}
                                             </td>
-                                            <td>{{ domain.dmarc_reports|length }}</td>
-                                            <td>{{ domain.smtptls_policies|length }}</td>
+                                            <td class="text-end">{{ domain.dmarc_reports|length }}</td>
+                                            <td class="text-end">{{ domain.smtptls_policies|length }}</td>
                                             <td class="text-nowrap">
                                                 <a href="{{ path('app_domains_edit', {id: domain.id}) }}" class="link-primary px-2">
                                                   <!-- Bootstrap icon 'eye-fill' -->

--- a/templates/domains/index.html.twig
+++ b/templates/domains/index.html.twig
@@ -8,7 +8,22 @@
                 <div class="row">
                     <div class="col-12 col-xl-12 mb-4 mb-lg-0">
                         <div class="card">
-                            <h5 class="card-header">Domains</h5>
+                            <h5 class="card-header d-flex justify-content-between">
+                              <span class="d-flex">Domains</span>
+                              <span class="d-flex">
+                              {% if pages.prev %}
+                                <a href="{{ path('app_domains', {page: pages.page - 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&lt;</a>
+                              {% else %}
+                                <a href="#" class="btn btn-sm btn-light" disabled>&lt;</a>
+                              {% endif %}
+                              &nbsp;
+                              {% if pages.next %}
+                                <a href="{{ path('app_domains', {page: pages.page + 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&gt;</a>
+                              {% else %}
+                                <a href="#" class="btn btn-sm btn-light" disabled>&gt;</a>
+                              {% endif %}
+                              </span>
+                            </h5>
                             <div class="card-body">
                                 <div class="table-responsive">
                                     <table class="table table-sm table-compact">
@@ -64,19 +79,6 @@
                                       </table>
                                 </div>
                                 <div>
-                                  <span class="d-flex justify-content-center">
-                                  {% if pages.prev %}
-                                    <a href="{{ path('app_domains', {page: pages.page - 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&lt;</a>
-                                  {% else %}
-                                    <a href="#" class="btn btn-sm btn-light" disabled>&lt;</a>
-                                  {% endif %}
-                                  &nbsp;
-                                  {% if pages.next %}
-                                    <a href="{{ path('app_domains', {page: pages.page + 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&gt;</a>
-                                  {% else %}
-                                    <a href="#" class="btn btn-sm btn-light" disabled>&gt;</a>
-                                  {% endif %}
-                                  </span>
                                 </div>
                                 
                             </div>

--- a/templates/logs/index.html.twig
+++ b/templates/logs/index.html.twig
@@ -6,7 +6,21 @@
                 <div class="row">
                     <div class="col-12 col-xl-12 mb-4 mb-lg-0">
                         <div class="card">
-                            <h5 class="card-header">Logs</h5>
+                            <h5 class="card-header d-flex justify-content-between">
+                              <span class="d-flex">Logs</span>
+                              <span class="d-flex">
+                              {% if pages.prev %}
+                                <a href="{{ path('app_logs', {page: pages.page - 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&lt;</a>
+                              {% else %}
+                                <a href="#" class="btn btn-sm btn-light" disabled>&lt;</a>
+                              {% endif %}
+                              {% if pages.next %}
+                                <a href="{{ path('app_logs', {page: pages.page + 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&gt;</a>
+                              {% else %}
+                                <a href="#" class="btn btn-sm btn-light" disabled>&gt;</a>
+                              {% endif %}
+                              </span>
+                            </h5>
                             <div class="card-body">
                                 <div class="table-responsive">
                                     <table class="table">
@@ -28,22 +42,6 @@
                                         </tbody>
                                       </table>
                                 </div>
-                                <div class="clearfix">
-                                  <span class="float-start">&nbsp;</span>
-                                  <span class="float-end">
-                                  {% if pages.prev %}
-                                    <a href="{{ path('app_logs', {page: pages.page - 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&lt;</a>
-                                  {% else %}
-                                    <a href="#" class="btn btn-sm btn-light" disabled>&lt;</a>
-                                  {% endif %}
-                                  {% if pages.next %}
-                                    <a href="{{ path('app_logs', {page: pages.page + 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&gt;</a>
-                                  {% else %}
-                                    <a href="#" class="btn btn-sm btn-light" disabled>&gt;</a>
-                                  {% endif %}
-                                  </span>
-                                </div>
-                                
                             </div>
                         </div>
                     </div>

--- a/templates/users/index.html.twig
+++ b/templates/users/index.html.twig
@@ -8,7 +8,22 @@
                 <div class="row">
                     <div class="col-12 col-xl-12 mb-4 mb-lg-0">
                         <div class="card">
-                            <h5 class="card-header">Users</h5>
+                            <h5 class="card-header d-flex justify-content-between">
+                              <span class="d-flex">Users</span>
+                              <span class="d-flex">
+                              {% if pages.prev %}
+                                <a href="{{ path('app_logs', {page: pages.page - 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&lt;</a>
+                              {% else %}
+                                <a href="#" class="btn btn-sm btn-light" disabled>&lt;</a>
+                              {% endif %}
+                              &nbsp;
+                              {% if pages.next %}
+                                <a href="{{ path('app_logs', {page: pages.page + 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&gt;</a>
+                              {% else %}
+                                <a href="#" class="btn btn-sm btn-light" disabled>&gt;</a>
+                              {% endif %}
+                              </span>
+                            </h5>
                             <div class="card-body">
                                 <div class="table-responsive">
                                     <table class="table">
@@ -17,7 +32,7 @@
                                             <th scope="col">E-Mail</th>
                                             <th scope="col">Verified</th>
                                             <th scope="col">Roles</th>
-                                            <th scope="col"></th>
+                                            <th scope="col">Action</th>
                                           </tr>
                                         </thead>
                                         <tbody>
@@ -42,39 +57,15 @@
                                                     {% if loop.index < loop.length -1 %},{% endif %}
                                                 {% endfor %}
                                             </td>
-                                            <td class="text-end">
-                                                <a href="{{ path('app_user_edit', {id: user.id}) }}" class="btn btn-sm btn-secondary" data-toggle="tooltip" data-placement="top" title="Edit">
-                                                  <svg height='20px' width='20px' xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                                                    <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
-                                                  </svg>
-                                                </a>
-                                                <a href="{{ path('app_user_delete', {id: user.id}) }}" class="btn btn-sm btn-danger" onclick="return confirm('{{'Are you sure? this can not be undone'|trans}}');" data-toggle="tooltip" data-placement="top" title="Delete">
-                                                  <svg height='20px' width='20px' xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
-                                                    <path stroke-linecap='round' stroke-linejoin='round' d='M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0' />
-                                                  </svg>
-                                                
+                                            <td>
+                                                <a href="{{ path('app_user_edit', {id: user.id}) }}" class="btn btn-sm btn-secondary">Edit</a>
+                                                <a href="{{ path('app_user_delete', {id: user.id}) }}" class="btn btn-sm btn-danger"  onclick="return confirm('{{'Are you sure? this can not be undone'|trans}}');">Delete</a>
                                             </td>
                                           </tr>
                                         {% endfor %}
                                         </tbody>
                                       </table>
                                 </div>
-                                <div class="clearfix">
-                                  <span class="float-start">&nbsp;</span>
-                                  <span class="float-end">
-                                  {% if pages.prev %}
-                                    <a href="{{ path('app_logs', {page: pages.page - 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&lt;</a>
-                                  {% else %}
-                                    <a href="#" class="btn btn-sm btn-light" disabled>&lt;</a>
-                                  {% endif %}
-                                  {% if pages.next %}
-                                    <a href="{{ path('app_logs', {page: pages.page + 1, perpage: pages.perpage }) }}" class="btn btn-sm btn-secondary">&gt;</a>
-                                  {% else %}
-                                    <a href="#" class="btn btn-sm btn-light" disabled>&gt;</a>
-                                  {% endif %}
-                                  </span>
-                                </div>
-                                
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
This is from #55 - but cleaned up a little and made easier to adapt for future changes.

I fixed the sidebar layout, added a touch sidebar (right side) for mobile small screens, made some table columns display depend on screen size, adjusted the breadcrumbs bar, decreased padding for the `card` CSS for small screens and added icons here and there. I also moved most "what to display" decisions into @media queries so changing these in batches is easier in the future.

Not all tables have been adjusted yet. I'll do the rest if you like the direction this is going.
One further idea is to also increase contrast for the `card`s, so they actually help guide the user.
Another is removing the `border-radius` for all items and going for a more material-like layout especially for small screens, that'll save another bit of space and make the overall UI even simpler. What do you think?

I did leave the top menu for medium screen sizes but you can easily hide it setting `display: none` in the the respective CSS @media(..) query. This way it's also up to every user to decide what they prefer. Positioning is not perfect yet there either.
