### PR TITLE
Correcting Titles in Tables - Capital Letter for Start of Word

### DIFF
--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -8,7 +8,7 @@
                 <div class="row">
                     <div class="col-12 col-xl-6 mb-4 mb-lg-4">
                         <div class="card">
-                            <h5 class="card-header">Latest DMARC reports</h5>
+                            <h5 class="card-header">Latest DMARC Reports</h5>
                             <div class="card-body">
                                 <div class="table-responsive">
                                     <table class="table">
@@ -77,7 +77,7 @@
                     </div>
                     <div class="col-12 col-xl-6 mb-4 mb-lg-4">
                         <div class="card">
-                            <h5 class="card-header">Latest SMTP-TLS reports</h5>
+                            <h5 class="card-header">Latest SMTP-TLS Reports</h5>
                             <div class="card-body">
                                 <div class="table-responsive">
                                     <table class="table">
@@ -171,7 +171,7 @@
                   <div class="row">
                     <div class="col-12 col-xl-12 mb-12 mb-lg-12">
                         <div class="card">
-                            <h5 class="card-header">Latest logs</h5>
+                            <h5 class="card-header">Latest Logs</h5>
                             <div class="card-body">
                                 <div class="table-responsive">
                                     <table class="table">


### PR DESCRIPTION
Correcting titles in table headers - correcting text case.