### PR TITLE
Dropdowns cut off

### DIFF
--- a/public/viesti.css
+++ b/public/viesti.css
@@ -11,3 +11,7 @@
     width: 18px;
     height: 18px;
 }
+
+.table-responsive {
+    overflow-x: inherit;
+}


### PR DESCRIPTION
While I'm familiarizing myself with your code, I'd like to fix a few little things. For example, I regularly have trouble accessing the dropdowns, as they are clipped by an overflow-x display.

Before:

![Image](https://github.com/user-attachments/assets/44da482d-b013-4c1c-bed3-04a7d2ab001d)

After:

![Image](https://github.com/user-attachments/assets/0ff69ca6-d6b9-407e-8b7c-4bead86c828d)