### PR TITLE
Error not shown due to missing page.title

### DIFF
--- a/src/Controller/SetupController.php
+++ b/src/Controller/SetupController.php
@@ -216,6 +216,7 @@ class SetupController extends AbstractController
             } catch (\Exception $e) {
                 return $this->render('base/error.html.twig', [
                     'message' => $e->getMessage(),
+                    'page'    => array('title' => $this->translator->trans('Setup')),
                 ]);
             }
         }


### PR DESCRIPTION
I got some errors while my first install. Instead of the real error i got "missing page.title", as the title is missing in exception.
